### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Iterate blazingly fast when defining view layouts by putting your AutoLayout con
 
 Suplementary blogpost: http://codeblog.shape.dk/blog/2013/12/16/live-editing-layout-constants-using-classy/
 
-This repository (and pod available through Cocoapods) contains the category `UIView+ClassyLayoutProperties` making it easy to define size and margin properties on views that can be set from a [Classy](http://classy.as) stylesheet and trigger `-updateConstraints` that can then easily be implemented using [Masonry](https://github.com/cloudkite/Masonry)'s `mas_updateConstraints:`. This pod also contains a number of convenient methods making it easy and declarative to define layouts with constants taken from the stylesheet.
+This repository (and pod available through CocoaPods) contains the category `UIView+ClassyLayoutProperties` making it easy to define size and margin properties on views that can be set from a [Classy](http://classy.as) stylesheet and trigger `-updateConstraints` that can then easily be implemented using [Masonry](https://github.com/cloudkite/Masonry)'s `mas_updateConstraints:`. This pod also contains a number of convenient methods making it easy and declarative to define layouts with constants taken from the stylesheet.
 
 
 In your view's -updateConstraints method you define a layout like this:


### PR DESCRIPTION

This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>
<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
